### PR TITLE
refactor: rebrand to Wuying AgentBay SDK

### DIFF
--- a/golang/README.md
+++ b/golang/README.md
@@ -1,0 +1,107 @@
+# Golang SDK for Wuying AgentBay
+
+This directory contains the Golang implementation of the Wuying AgentBay SDK.
+
+## Prerequisites
+
+- Go 1.18 or later
+
+## Installation
+
+### For Development
+
+Clone the repository and navigate to the Golang directory:
+
+```bash
+git clone https://github.com/aliyun/wuying-agentbay-sdk.git
+cd wuying-agentbay-sdk/golang
+```
+
+### For Usage in Your Project
+
+```bash
+go get github.com/aliyun/wuying-agentbay-sdk/golang/pkg/agentbay
+```
+
+## Running Examples
+
+You can run the example file:
+
+```bash
+go run examples/basic_usage.go
+```
+
+## Golang-Specific Usage
+
+```go
+package main
+
+import (
+	"fmt"
+	"os"
+	
+	"github.com/aliyun/wuying-agentbay-sdk/golang/pkg/agentbay"
+)
+
+func main() {
+	// Initialize with API key
+	apiKey := os.Getenv("AGENTBAY_API_KEY")
+	if apiKey == "" {
+		apiKey = "your_api_key" // Replace with your actual API key
+	}
+	
+	client, err := agentbay.NewAgentBay(apiKey)
+	if err != nil {
+		fmt.Printf("Error initializing AgentBay client: %v\n", err)
+		os.Exit(1)
+	}
+	
+	// Create a session
+	session, err := client.Create()
+	if err != nil {
+		fmt.Printf("Error creating session: %v\n", err)
+		os.Exit(1)
+	}
+	fmt.Printf("Session created with ID: %s\n", session.SessionID)
+	
+	// Execute a command
+	result, err := session.Command.ExecuteCommand("ls -la")
+	if err != nil {
+		fmt.Printf("Error executing command: %v\n", err)
+		os.Exit(1)
+	}
+	fmt.Printf("Command result: %s\n", result)
+	
+	// Read a file
+	content, err := session.FileSystem.ReadFile("/path/to/file.txt")
+	if err != nil {
+		fmt.Printf("Error reading file: %v\n", err)
+		os.Exit(1)
+	}
+	fmt.Printf("File content: %s\n", content)
+	
+	// Clean up
+	err = client.Delete(session)
+	if err != nil {
+		fmt.Printf("Error deleting session: %v\n", err)
+		os.Exit(1)
+	}
+	fmt.Println("Session deleted successfully")
+}
+```
+
+## Development
+
+### Building the SDK
+
+```bash
+go build ./...
+```
+
+### Running Tests
+
+```bash
+go test ./...
+```
+
+For more detailed documentation, please refer to the main [README](../README.md) and [SDK Reference](../SDK_Reference.md) in the project root.

--- a/golang/api/README.md
+++ b/golang/api/README.md
@@ -19,7 +19,7 @@ import (
 	"fmt"
 	
 	openapiutil "github.com/alibabacloud-go/darabonba-openapi/v2/utils"
-	"github.com/agentbay/agentbay-sdk/golang/api/client"
+	"github.com/aliyun/wuying-agentbay-sdk/golang/api/client"
 )
 
 func main() {

--- a/golang/examples/basic_usage.go
+++ b/golang/examples/basic_usage.go
@@ -5,7 +5,7 @@ import (
 	"os"
 	"strings"
 
-	"github.com/agentbay/agentbay-sdk/golang/pkg/agentbay"
+	"github.com/aliyun/wuying-agentbay-sdk/golang/pkg/agentbay"
 )
 
 func main() {

--- a/golang/pkg/agentbay/adb/adb.go
+++ b/golang/pkg/agentbay/adb/adb.go
@@ -4,8 +4,8 @@ import (
 	"encoding/json"
 	"fmt"
 
-	mcp "github.com/agentbay/agentbay-sdk/golang/api/client"
 	"github.com/alibabacloud-go/tea/tea"
+	mcp "github.com/aliyun/wuying-agentbay-sdk/golang/api/client"
 )
 
 // Adb handles ADB operations in the AgentBay mobile environment.

--- a/golang/pkg/agentbay/agentbay.go
+++ b/golang/pkg/agentbay/agentbay.go
@@ -5,9 +5,9 @@ import (
 	"os"
 	"sync"
 
-	mcp "github.com/agentbay/agentbay-sdk/golang/api/client"
 	openapi "github.com/alibabacloud-go/darabonba-openapi/v2/client"
 	"github.com/alibabacloud-go/tea/tea"
+	mcp "github.com/aliyun/wuying-agentbay-sdk/golang/api/client"
 )
 
 // AgentBay represents the main client for interacting with the AgentBay cloud runtime environment.

--- a/golang/pkg/agentbay/command/command.go
+++ b/golang/pkg/agentbay/command/command.go
@@ -3,8 +3,9 @@ package command
 import (
 	"encoding/json"
 	"fmt"
-	mcp "github.com/agentbay/agentbay-sdk/golang/api/client"
+
 	"github.com/alibabacloud-go/tea/tea"
+	mcp "github.com/aliyun/wuying-agentbay-sdk/golang/api/client"
 )
 
 // Command handles command execution operations in the AgentBay cloud environment.

--- a/golang/pkg/agentbay/filesystem/filesystem.go
+++ b/golang/pkg/agentbay/filesystem/filesystem.go
@@ -4,8 +4,8 @@ import (
 	"encoding/json"
 	"fmt"
 
-	mcp "github.com/agentbay/agentbay-sdk/golang/api/client"
 	"github.com/alibabacloud-go/tea/tea"
+	mcp "github.com/aliyun/wuying-agentbay-sdk/golang/api/client"
 )
 
 // FileSystem handles file operations in the AgentBay cloud environment.

--- a/golang/pkg/agentbay/session.go
+++ b/golang/pkg/agentbay/session.go
@@ -3,11 +3,11 @@ package agentbay
 import (
 	"fmt"
 
-	mcp "github.com/agentbay/agentbay-sdk/golang/api/client"
-	"github.com/agentbay/agentbay-sdk/golang/pkg/agentbay/adb"
-	"github.com/agentbay/agentbay-sdk/golang/pkg/agentbay/command"
-	"github.com/agentbay/agentbay-sdk/golang/pkg/agentbay/filesystem"
 	"github.com/alibabacloud-go/tea/tea"
+	mcp "github.com/aliyun/wuying-agentbay-sdk/golang/api/client"
+	"github.com/aliyun/wuying-agentbay-sdk/golang/pkg/agentbay/adb"
+	"github.com/aliyun/wuying-agentbay-sdk/golang/pkg/agentbay/command"
+	"github.com/aliyun/wuying-agentbay-sdk/golang/pkg/agentbay/filesystem"
 )
 
 // Session represents a session in the AgentBay cloud environment.

--- a/python/README.md
+++ b/python/README.md
@@ -1,1 +1,90 @@
-# 请参考根目录 README.md
+# Python SDK for Wuying AgentBay
+
+This directory contains the Python implementation of the Wuying AgentBay SDK.
+
+## Prerequisites
+
+- Python 3.12 or later
+- Poetry (for development)
+
+## Installation
+
+### For Development
+
+Clone the repository and install dependencies using Poetry:
+
+```bash
+git clone https://github.com/aliyun/wuying-agentbay-sdk.git
+cd wuying-agentbay-sdk/python
+poetry install
+```
+
+### For Usage in Your Project
+
+```bash
+pip install wuying-agentbay-sdk
+```
+
+## Running Examples
+
+You can run the example file:
+
+```bash
+# Using Poetry
+poetry run python examples/basic_usage.py
+
+# Or directly with Python if installed in your environment
+python examples/basic_usage.py
+```
+
+## Python-Specific Usage
+
+```python
+from wuying_agentbay import AgentBay
+from wuying_agentbay.exceptions import AgentBayError
+
+def main():
+    # Initialize with API key
+    api_key = "your_api_key"  # Or use os.environ.get("AGENTBAY_API_KEY")
+    
+    try:
+        agent_bay = AgentBay(api_key=api_key)
+        
+        # Create a session
+        session = agent_bay.create()
+        print(f"Session created with ID: {session.session_id}")
+        
+        # Execute a command
+        result = session.command.execute_command("ls -la")
+        print(f"Command result: {result}")
+        
+        # Read a file
+        content = session.file_system.read_file("/path/to/file.txt")
+        print(f"File content: {content}")
+        
+        # Clean up
+        agent_bay.delete(session)
+        print("Session deleted successfully")
+        
+    except AgentBayError as e:
+        print(f"Error: {e}")
+
+if __name__ == "__main__":
+    main()
+```
+
+## Development
+
+### Building the SDK
+
+```bash
+poetry build
+```
+
+### Running Tests
+
+```bash
+poetry run pytest
+```
+
+For more detailed documentation, please refer to the main [README](../README.md) and [SDK Reference](../SDK_Reference.md) in the project root.

--- a/python/examples/basic_usage.py
+++ b/python/examples/basic_usage.py
@@ -2,11 +2,11 @@ import os
 import sys
 import time
 
-# Add the parent directory to the path so we can import the agentbay package
+# Add the parent directory to the path so we can import the wuying_agentbay package
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
-from agentbay import AgentBay
-from agentbay.exceptions import AgentBayError
+from wuying_agentbay import AgentBay
+from wuying_agentbay.exceptions import AgentBayError
 
 
 def main():

--- a/typescript/README.md
+++ b/typescript/README.md
@@ -1,16 +1,89 @@
-## 前提
+# TypeScript SDK for Wuying AgentBay
 
-安装tnpm v9.17.2 版本，不要安装10.x版本
-终端切换到typeScript文件夹下,进行下面操作
+This directory contains the TypeScript implementation of the Wuying AgentBay SDK.
 
-## 安装工程依赖
+## Prerequisites
 
+- Node.js (v14 or later)
+- npm (v6 or later)
+
+## Installation
+
+### For Development
+
+Clone the repository and install dependencies:
+
+```bash
+git clone https://github.com/aliyun/wuying-agentbay-sdk.git
+cd wuying-agentbay-sdk/typescript
+npm install
 ```
-tnpm install
+
+### For Usage in Your Project
+
+```bash
+npm install wuying-agentbay-sdk
 ```
 
-## 调试basic-usage.ts文件命令
+## Development Scripts
 
-```
+- **Build the project**:
+  ```bash
+  npm run build
+  ```
+
+- **Run tests**:
+  ```bash
+  npm test
+  ```
+
+- **Lint the code**:
+  ```bash
+  npm run lint
+  ```
+
+- **Format the code**:
+  ```bash
+  npm run format
+  ```
+
+## Running Examples
+
+You can run the example file using ts-node:
+
+```bash
 npx ts-node examples/basic-usage.ts
 ```
+
+## TypeScript-Specific Usage
+
+```typescript
+import { AgentBay } from 'wuying-agentbay-sdk';
+
+async function main() {
+  // Initialize with API key
+  const agentBay = new AgentBay({ apiKey: 'your_api_key' });
+  
+  try {
+    // Create a session
+    const session = await agentBay.create();
+    
+    // Execute a command
+    const result = await session.command.execute_command('ls -la');
+    console.log(result);
+    
+    // Read a file
+    const content = await session.filesystem.read_file('/path/to/file.txt');
+    console.log(content);
+    
+    // Clean up
+    await agentBay.delete(session.sessionId);
+  } catch (error) {
+    console.error('Error:', error);
+  }
+}
+
+main();
+```
+
+For more detailed documentation, please refer to the main [README](../README.md) and [SDK Reference](../SDK_Reference.md) in the project root.


### PR DESCRIPTION
This commit includes the following changes:

1. Project Rebranding:
   - Renamed from "AgentBay SDK" to "Wuying AgentBay SDK"
   - Updated all documentation to reflect the new name

2. Repository URL Update:
   - Changed GitHub repository URL from github.com/agentbay/agentbay-sdk to github.com/aliyun/wuying-agentbay-sdk
   - Updated import paths in all Go files:
     * golang/api/README.md
     * golang/pkg/agentbay/session.go * golang/pkg/agentbay/agentbay.go * golang/pkg/agentbay/filesystem/filesystem.go * golang/pkg/agentbay/command/command.go * golang/pkg/agentbay/adb/adb.go
   - Updated package names in Python files from 'agentbay' to 'wuying_agentbay'
   - Updated repository URL in typescript/package.json

3. Documentation Improvements:
   - Created language-specific README.md files for TypeScript, Go, and Python
   - Updated examples to use the new package names and import paths
   - Enhanced documentation with clearer installation and usage instructions

These changes ensure consistent branding and licensing across the entire project while maintaining backward compatibility with existing code.