### PR TITLE
fix: correct browser image ID from browser-latest to browser_latest

### DIFF
--- a/python/docs/examples/browser/admin_add_product.py
+++ b/python/docs/examples/browser/admin_add_product.py
@@ -18,7 +18,7 @@ async def main():
         print("Error: AGENTBAY_API_KEY not set")
         return
     agentbay = AgentBay(api_key=api_key)
-    session = agentbay.create(CreateSessionParams(image_id="browser-latest")).session
+    session = agentbay.create(CreateSessionParams(image_id="browser_latest")).session
     try:
         if not await session.browser.initialize_async(BrowserOption()):
             print("Browser init failed")

--- a/python/docs/examples/browser/alimeeting_availability.py
+++ b/python/docs/examples/browser/alimeeting_availability.py
@@ -19,7 +19,7 @@ async def main():
         return
     agent_bay = AgentBay(api_key=api_key)
 
-    session = agent_bay.create(CreateSessionParams(image_id="browser-latest")).session
+    session = agent_bay.create(CreateSessionParams(image_id="browser_latest")).session
     try:
         if not await session.browser.initialize_async(BrowserOption()):
             print("Browser init failed")

--- a/python/docs/examples/browser/shop_inspector.py
+++ b/python/docs/examples/browser/shop_inspector.py
@@ -229,7 +229,7 @@ async def main():
 
     date_str = datetime.now().strftime("%Y-%m-%d")
     agent_bay = AgentBay(api_key=api_key)
-    params = CreateSessionParams(image_id="browser-latest")
+    params = CreateSessionParams(image_id="browser_latest")
     session_result = agent_bay.create(params)
     if not session_result.success:
         print(f"Failed to create session: {session_result.error_message}")


### PR DESCRIPTION
Replace incorrect hyphenated browser-latest with correct underscore version browser_latest in browser example files.

Affected files:
- python/docs/examples/browser/admin_add_product.py
- python/docs/examples/browser/alimeeting_availability.py
- python/docs/examples/browser/shop_inspector.py

🤖 Generated with [Claude Code]