### PR TITLE
docs: add missing mobile documentation links to main README

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -77,6 +77,8 @@ Mobile UI automation for app testing and gesture-based interactions.
 
 - [Mobile Application Management](guides/mobile-use/mobile-application-management.md) - Mobile app control and management
 - [Mobile UI Automation](guides/mobile-use/mobile-ui-automation.md) - Mobile UI interaction and automation
+- [ADB Connection](guides/mobile-use/adb-connection.md) - ADB connection and debugging capabilities
+- [Mobile Session Configuration](guides/mobile-use/mobile-session-configuration.md) - Advanced mobile session configuration options
 
 **Key Capabilities:**
 - UI Element Detection
@@ -84,6 +86,7 @@ Mobile UI automation for app testing and gesture-based interactions.
 - Key Events and Swipe Gestures
 - Screenshot Capture
 - Mobile Application Management
+- ADB Connection and Debugging
 
 #### [CodeSpace](guides/codespace/README.md)
 Development environment for code execution and scripting.


### PR DESCRIPTION
Add links to ADB Connection and Mobile Session Configuration guides in the Mobile Use section of the main documentation README.

Changes:
- Add link to ADB Connection guide
- Add link to Mobile Session Configuration guide
- Add "ADB Connection and Debugging" to Key Capabilities list

🤖 Generated with [Claude Code]