### PR TITLE
docs: update API documentation links to new directory structure

### DIFF
--- a/docs/guides/common-features/advanced/agent-modules.md
+++ b/docs/guides/common-features/advanced/agent-modules.md
@@ -80,4 +80,4 @@ If you encounter issues with Agent modules:
 2. Search [GitHub Issues](https://github.com/aliyun/wuying-agentbay-sdk/issues) for similar problems
 3. Contact support with detailed error information and reproduction steps
 4. Please refer to the [Agent Task Excution Example](../../../../python/docs/examples/agent_module/main.py) to see how to use the Agent.
-5. Please refer to the [Agent API Definition](../../../../python/docs/api/agent.md) for more details.
+5. Please refer to the [Agent API Definition](../../../../python/docs/api/common-features/advanced/agent.md) for more details.

--- a/docs/guides/common-features/basics/session-management.md
+++ b/docs/guides/common-features/basics/session-management.md
@@ -444,12 +444,12 @@ except Exception as e:
 ## API Reference
 
 For detailed API documentation, see:
-- [Python Session API](../../../../python/docs/api/session.md)
-- [TypeScript Session API](../../../../typescript/docs/api/session.md)
-- [Golang Session API](../../../../golang/docs/api/session.md)
-- [Python AgentBay API](../../../../python/docs/api/agentbay.md)
-- [TypeScript AgentBay API](../../../../typescript/docs/api/agentbay.md)
-- [Golang AgentBay API](../../../../golang/docs/api/agentbay.md)
+- [Python Session API](../../../../python/docs/api/common-features/basics/session.md)
+- [TypeScript Session API](../../../../typescript/docs/api/common-features/basics/session.md)
+- [Golang Session API](../../../../golang/docs/api/common-features/basics/session.md)
+- [Python AgentBay API](../../../../python/docs/api/common-features/basics/agentbay.md)
+- [TypeScript AgentBay API](../../../../typescript/docs/api/common-features/basics/agentbay.md)
+- [Golang AgentBay API](../../../../golang/docs/api/common-features/basics/agentbay.md)
 
 ## 📚 Related Guides
 

--- a/docs/guides/common-features/configuration/logging.md
+++ b/docs/guides/common-features/configuration/logging.md
@@ -4,9 +4,9 @@ This guide shows how to configure logging in AgentBay SDK. Each language has its
 
 ## Quick Links
 
-- **[Python Logging Guide](../../../../python/docs/api/logging.md)** - Setup, configuration, and file logging
-- **[Go Logging Guide](../../../../golang/docs/api/logging.md)** - Environment variables and code-level configuration
-- **[TypeScript Logging Guide](../../../../typescript/docs/api/logging.md)** - Import-time setup and RequestID tracking
+- **[Python Logging Guide](../../../../python/docs/api/common-features/basics/logging.md)** - Setup, configuration, and file logging
+- **[Go Logging Guide](../../../../golang/docs/api/common-features/basics/logging.md)** - Environment variables and code-level configuration
+- **[TypeScript Logging Guide](../../../../typescript/docs/api/common-features/basics/logging.md)** - Import-time setup and RequestID tracking
 
 ---
 

--- a/docs/guides/mobile-use/adb-connection.md
+++ b/docs/guides/mobile-use/adb-connection.md
@@ -400,9 +400,9 @@ which adb
 
 For detailed API documentation in other languages:
 
-- **Python**: [Mobile API Documentation](../../../python/docs/api/mobile.md#get_adb_url)
-- **Golang**: [Mobile API Documentation](../../../golang/docs/api/mobile.md#getadburl)
-- **TypeScript**: [Mobile API Documentation](../../../typescript/docs/api/mobile.md#getadburl)
+- **Python**: [Mobile API Documentation](../../../python/docs/api/mobile-use/mobile.md#get_adb_url)
+- **Golang**: [Mobile API Documentation](../../../golang/docs/api/mobile-use/mobile.md#getadburl)
+- **TypeScript**: [Mobile API Documentation](../../../typescript/docs/api/mobile-use/mobile.md#getadburl)
 
 ## Example Code
 

--- a/typescript/docs/examples/browser-use/extension-example/README.md
+++ b/typescript/docs/examples/browser-use/extension-example/README.md
@@ -239,14 +239,14 @@ try {
 
 ## Next Steps
 
-- Explore the complete API documentation at `typescript/docs/api/extension.md`
+- Explore the complete API documentation at `typescript/docs/api/browser-use/extension.md`
 - Check browser automation examples for integration patterns
 - Review the AgentBay SDK documentation for advanced features
 - Consider implementing custom validation and testing workflows
 
 ## Related Resources
 
-- [Extension API Reference](../../api/extension.md) - Complete API documentation
-- [Session API Reference](../../api/session.md) - Browser session management
-- [Context API Reference](../../api/context.md) - Context management
-- [AgentBay SDK Documentation](../../api/agentbay.md) - Core SDK features
+- [Extension API Reference](../../api/browser-use/extension.md) - Complete API documentation
+- [Session API Reference](../../api/common-features/basics/session.md) - Browser session management
+- [Context API Reference](../../api/common-features/basics/context.md) - Context management
+- [AgentBay SDK Documentation](../../api/common-features/basics/agentbay.md) - Core SDK features


### PR DESCRIPTION
Update all API documentation links to reflect the new organized directory structure. Links now point to categorized subdirectories instead of flat structure.

Changes:
- Update logging guide links (3 files x 3 languages)
- Update session management API references (6 files x 3 languages)
- Update agent module API reference
- Update mobile API documentation links (3 languages)
- Update browser extension example links (4 references)

All links verified to point to existing files.

🤖 Generated with [Claude Code]