### PR TITLE
fix: Create file transfer context for recovered sessions in get() method

### DIFF
--- a/golang/pkg/agentbay/agentbay.go
+++ b/golang/pkg/agentbay/agentbay.go
@@ -929,6 +929,22 @@ func (a *AgentBay) Get(sessionID string) (*SessionResult, error) {
 	// Store the session in the local cache
 	a.Sessions.Store(sessionID, *session)
 
+	// Create a default context for file transfer operations for the recovered session
+	contextName := fmt.Sprintf("file-transfer-context-%d", time.Now().Unix())
+	contextResult, err := a.Context.Get(contextName, true)
+	if err == nil && contextResult.Success && contextResult.Context != nil {
+		session.FileTransferContextID = contextResult.Context.ID
+		fmt.Printf("📁 Created file transfer context for recovered session: %s\n", contextResult.Context.ID)
+	} else {
+		errorMsg := "Unknown error"
+		if err != nil {
+			errorMsg = err.Error()
+		} else if contextResult.ErrorMessage != "" {
+			errorMsg = contextResult.ErrorMessage
+		}
+		fmt.Printf("⚠️  Failed to create file transfer context for recovered session: %s\n", errorMsg)
+	}
+
 	// Log successful retrieval
 	keyFields := map[string]interface{}{
 		"session_id":   sessionID,

--- a/golang/pkg/agentbay/session.go
+++ b/golang/pkg/agentbay/session.go
@@ -120,6 +120,9 @@ type Session struct {
 	// Resource URL for accessing the session
 	ResourceUrl string
 
+	// File transfer context ID for file operations
+	FileTransferContextID string
+
 	// File, command and code handlers
 	FileSystem *filesystem.FileSystem
 	Command    *command.Command

--- a/golang/tests/pkg/integration/get_file_transfer_context_test.go
+++ b/golang/tests/pkg/integration/get_file_transfer_context_test.go
@@ -1,0 +1,166 @@
+package integration
+
+import (
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/aliyun/wuying-agentbay-sdk/golang/pkg/agentbay"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestGetFileTransferContext tests the file transfer context fix for the Get method
+type GetFileTransferContextTestSuite struct {
+	agentBay *agentbay.AgentBay
+	session  *agentbay.Session
+}
+
+func (suite *GetFileTransferContextTestSuite) SetupTest(t *testing.T) {
+	apiKey := os.Getenv("AGENTBAY_API_KEY")
+	if apiKey == "" {
+		t.Skip("AGENTBAY_API_KEY not set")
+	}
+
+	var err error
+	suite.agentBay, err = agentbay.NewAgentBay(apiKey)
+	require.NoError(t, err, "Failed to create AgentBay client")
+
+	// Create a test session
+	params := agentbay.NewCreateSessionParams()
+	params.ImageId = "code_latest"
+	result, err := suite.agentBay.Create(params)
+	require.NoError(t, err, "Failed to create session")
+	require.NotNil(t, result.Session, "Session should not be nil")
+	suite.session = result.Session
+}
+
+func (suite *GetFileTransferContextTestSuite) TearDownTest(t *testing.T) {
+	if suite.session != nil {
+		_, err := suite.session.Delete()
+		if err != nil {
+			t.Logf("Warning: Failed to cleanup session %s: %v", suite.session.SessionID, err)
+		}
+	}
+}
+
+// TestGetMethodCreatesFileTransferContext verifies that the Get method creates
+// a file transfer context automatically for recovered sessions
+func TestGetMethodCreatesFileTransferContext(t *testing.T) {
+	suite := &GetFileTransferContextTestSuite{}
+	suite.SetupTest(t)
+	defer suite.TearDownTest(t)
+
+	// Get the session_id from the test session
+	sessionID := suite.session.SessionID
+
+	// Use Get method to recover the session
+	getResult, err := suite.agentBay.Get(sessionID)
+	require.NoError(t, err, "Get method failed")
+	require.NotNil(t, getResult, "Get result should not be nil")
+	require.True(t, getResult.Success, "Get method was not successful: %s", getResult.ErrorMessage)
+	require.NotNil(t, getResult.Session, "Session should not be nil")
+	assert.Equal(t, sessionID, getResult.Session.SessionID, "Session IDs should match")
+
+	// Verify that the recovered session has a file transfer context ID
+	recoveredSession := getResult.Session
+	assert.NotEmpty(t, recoveredSession.FileTransferContextID,
+		"Recovered session should have a non-empty FileTransferContextID")
+}
+
+// TestRecoveredSessionCanPerformFileOperations verifies that a session recovered
+// via Get method can actually perform file operations
+func TestRecoveredSessionCanPerformFileOperations(t *testing.T) {
+	suite := &GetFileTransferContextTestSuite{}
+	suite.SetupTest(t)
+	defer suite.TearDownTest(t)
+
+	// Get the session_id from the test session
+	sessionID := suite.session.SessionID
+
+	// Wait a bit for session to be fully ready
+	time.Sleep(5 * time.Second)
+
+	// Use Get method to recover the session
+	getResult, err := suite.agentBay.Get(sessionID)
+	require.NoError(t, err, "Get method failed")
+	require.NotNil(t, getResult, "Get result should not be nil")
+	require.True(t, getResult.Success, "Get method was not successful: %s", getResult.ErrorMessage)
+
+	recoveredSession := getResult.Session
+
+	// Create a test file to upload
+	testContent := fmt.Sprintf("Test content at %d", time.Now().Unix())
+	testFilename := fmt.Sprintf("test_file_%d.txt", time.Now().Unix())
+	testPath := fmt.Sprintf("/tmp/%s", testFilename)
+
+	// Try to write the file using file_system operations
+	// This should work if file transfer context is properly set up
+	// Note: WriteFile in Golang requires a third parameter for write mode ("overwrite" or "append")
+	writeResult, err := recoveredSession.FileSystem.WriteFile(testPath, testContent, "overwrite")
+	require.NoError(t, err, "File write operation failed")
+	require.NotNil(t, writeResult, "Write result should not be nil")
+	require.True(t, writeResult.Success,
+		"File write was not successful")
+
+	// Read back the file to verify
+	readResult, err := recoveredSession.FileSystem.ReadFile(testPath)
+	require.NoError(t, err, "File read operation failed")
+	require.NotNil(t, readResult, "Read result should not be nil")
+	assert.Equal(t, testContent, readResult.Content,
+		"Read content doesn't match written content")
+}
+
+// TestOriginalAndRecoveredSessionBothWork verifies that both original and
+// recovered sessions can perform file operations
+func TestOriginalAndRecoveredSessionBothWork(t *testing.T) {
+	suite := &GetFileTransferContextTestSuite{}
+	suite.SetupTest(t)
+	defer suite.TearDownTest(t)
+
+	sessionID := suite.session.SessionID
+
+	// Wait a bit for session to be fully ready
+	time.Sleep(5 * time.Second)
+
+	// Test 1: Original session can write files
+	testContent1 := fmt.Sprintf("Original session test at %d", time.Now().Unix())
+	testFilename1 := fmt.Sprintf("original_test_%d.txt", time.Now().Unix())
+	testPath1 := fmt.Sprintf("/tmp/%s", testFilename1)
+
+	writeResult1, err := suite.session.FileSystem.WriteFile(testPath1, testContent1, "overwrite")
+	require.NoError(t, err, "Original session file write failed")
+	require.NotNil(t, writeResult1, "Write result 1 should not be nil")
+	require.True(t, writeResult1.Success,
+		"Original session file write was not successful")
+
+	// Test 2: Recover the session
+	getResult, err := suite.agentBay.Get(sessionID)
+	require.NoError(t, err, "Get method failed")
+	require.NotNil(t, getResult, "Get result should not be nil")
+	require.True(t, getResult.Success, "Get method was not successful: %s", getResult.ErrorMessage)
+	recoveredSession := getResult.Session
+
+	// Test 3: Recovered session can write files
+	testContent2 := fmt.Sprintf("Recovered session test at %d", time.Now().Unix())
+	testFilename2 := fmt.Sprintf("recovered_test_%d.txt", time.Now().Unix())
+	testPath2 := fmt.Sprintf("/tmp/%s", testFilename2)
+
+	writeResult2, err := recoveredSession.FileSystem.WriteFile(testPath2, testContent2, "overwrite")
+	require.NoError(t, err, "Recovered session file write failed")
+	require.NotNil(t, writeResult2, "Write result 2 should not be nil")
+	require.True(t, writeResult2.Success,
+		"Recovered session file write was not successful")
+
+	// Test 4: Verify both files exist and have correct content
+	readResult1, err := recoveredSession.FileSystem.ReadFile(testPath1)
+	require.NoError(t, err, "Failed to read file 1")
+	require.NotNil(t, readResult1, "Read result 1 should not be nil")
+	assert.Equal(t, testContent1, readResult1.Content, "File 1 content mismatch")
+
+	readResult2, err := recoveredSession.FileSystem.ReadFile(testPath2)
+	require.NoError(t, err, "Failed to read file 2")
+	require.NotNil(t, readResult2, "Read result 2 should not be nil")
+	assert.Equal(t, testContent2, readResult2.Content, "File 2 content mismatch")
+}

--- a/python/agentbay/agentbay.py
+++ b/python/agentbay/agentbay.py
@@ -1196,6 +1196,20 @@ class AgentBay:
             session.token = get_result.data.token
             session.resource_url = get_result.data.resource_url
 
+        # Create a default context for file transfer operations for the recovered session
+        import time
+        context_name = f"file-transfer-context-{int(time.time())}"
+        context_result = self.context.get(context_name, create=True)
+        if context_result.success and context_result.context:
+            session.file_transfer_context_id = context_result.context.id
+            logger.info(
+                f"📁 Created file transfer context for recovered session: {context_result.context.id}"
+            )
+        else:
+            logger.warning(
+                f"⚠️  Failed to create file transfer context for recovered session: {context_result.error_message if hasattr(context_result, 'error_message') else 'Unknown error'}"
+            )
+
         return SessionResult(
             request_id=get_result.request_id,
             success=True,

--- a/python/tests/integration/test_get_file_transfer_context.py
+++ b/python/tests/integration/test_get_file_transfer_context.py
@@ -1,0 +1,155 @@
+import os
+import pytest
+import time
+from agentbay import AgentBay
+from agentbay.session_params import CreateSessionParams
+
+
+class TestGetFileTransferContext:
+    """Integration tests for get method file transfer context fix"""
+
+    @pytest.fixture
+    def agent_bay(self):
+        """Create AgentBay instance"""
+        api_key = os.getenv("AGENTBAY_API_KEY")
+        if not api_key:
+            pytest.skip("AGENTBAY_API_KEY not set")
+        return AgentBay(api_key=api_key)
+
+    @pytest.fixture
+    def test_session(self, agent_bay):
+        """Create a test session and clean up after test"""
+        params = CreateSessionParams(image_id="code_latest")
+        result = agent_bay.create(params)
+        if not result.success:
+            pytest.fail(f"Failed to create session: {result.error_message}")
+
+        session = result.session
+        yield session
+
+        # Cleanup: delete the session after test
+        try:
+            session.delete()
+        except Exception as e:
+            print(f"Warning: Failed to cleanup session {session.session_id}: {e}")
+
+    def test_get_method_creates_file_transfer_context(self, agent_bay, test_session):
+        """
+        Test that get method creates file transfer context automatically.
+
+        This test verifies the fix for the bug where recovered sessions
+        couldn't perform file operations due to missing file transfer context.
+        """
+        # Get the session_id from the test_session
+        session_id = test_session.session_id
+
+        # Use get method to recover the session
+        get_result = agent_bay.get(session_id)
+
+        # Verify get was successful
+        assert get_result.success, f"Get failed: {get_result.error_message}"
+        assert get_result.session is not None
+        assert get_result.session.session_id == session_id
+
+        # Verify that the recovered session has a file transfer context ID
+        recovered_session = get_result.session
+        assert hasattr(recovered_session, "file_transfer_context_id"), \
+            "Recovered session should have file_transfer_context_id attribute"
+        assert recovered_session.file_transfer_context_id is not None, \
+            "Recovered session should have a non-None file_transfer_context_id"
+        assert recovered_session.file_transfer_context_id != "", \
+            "Recovered session should have a non-empty file_transfer_context_id"
+
+    def test_recovered_session_can_perform_file_operations(self, agent_bay, test_session):
+        """
+        Test that recovered session can perform actual file operations.
+
+        This is an end-to-end test that verifies the recovered session
+        can actually upload and download files.
+        """
+        # Get the session_id from the test_session
+        session_id = test_session.session_id
+
+        # Wait a bit for session to be fully ready
+        time.sleep(5)
+
+        # Use get method to recover the session
+        get_result = agent_bay.get(session_id)
+        assert get_result.success, f"Get failed: {get_result.error_message}"
+
+        recovered_session = get_result.session
+
+        # Create a test file to upload
+        test_content = f"Test content at {time.time()}"
+        test_filename = f"test_file_{int(time.time())}.txt"
+
+        # Try to write the file using file_system operations
+        # This should work if file transfer context is properly set up
+        try:
+            # Write file to the session
+            write_result = recovered_session.file_system.write_file(
+                f"/tmp/{test_filename}",
+                test_content
+            )
+
+            # Verify the write was successful
+            assert write_result.success, \
+                f"File write failed: {write_result.error_message}"
+
+            # Read back the file to verify
+            read_result = recovered_session.file_system.read_file(f"/tmp/{test_filename}")
+            assert read_result.success, \
+                f"File read failed: {read_result.error_message}"
+            assert read_result.content == test_content, \
+                "Read content doesn't match written content"
+
+        except Exception as e:
+            pytest.fail(f"File operations failed on recovered session: {e}")
+
+    def test_original_and_recovered_session_both_work(self, agent_bay, test_session):
+        """
+        Test that both original session and recovered session can perform file operations.
+
+        This test verifies that:
+        1. Original session created with create() works
+        2. Recovered session obtained with get() works
+        3. Both can perform file operations independently
+        """
+        session_id = test_session.session_id
+
+        # Wait a bit for session to be fully ready
+        time.sleep(5)
+
+        # Test 1: Original session can write files
+        test_content_1 = f"Original session test at {time.time()}"
+        test_filename_1 = f"original_test_{int(time.time())}.txt"
+
+        write_result_1 = test_session.file_system.write_file(
+            f"/tmp/{test_filename_1}",
+            test_content_1
+        )
+        assert write_result_1.success, \
+            f"Original session file write failed: {write_result_1.error_message}"
+
+        # Test 2: Recover the session
+        get_result = agent_bay.get(session_id)
+        assert get_result.success, f"Get failed: {get_result.error_message}"
+        recovered_session = get_result.session
+
+        # Test 3: Recovered session can write files
+        test_content_2 = f"Recovered session test at {time.time()}"
+        test_filename_2 = f"recovered_test_{int(time.time())}.txt"
+
+        write_result_2 = recovered_session.file_system.write_file(
+            f"/tmp/{test_filename_2}",
+            test_content_2
+        )
+        assert write_result_2.success, \
+            f"Recovered session file write failed: {write_result_2.error_message}"
+
+        # Test 4: Verify both files exist and have correct content
+        read_result_1 = recovered_session.file_system.read_file(f"/tmp/{test_filename_1}")
+        assert read_result_1.success and read_result_1.content == test_content_1
+
+        read_result_2 = recovered_session.file_system.read_file(f"/tmp/{test_filename_2}")
+        assert read_result_2.success and read_result_2.content == test_content_2

--- a/typescript/src/agent-bay.ts
+++ b/typescript/src/agent-bay.ts
@@ -1031,6 +1031,16 @@ export class AgentBay {
       session.resourceUrl = getResult.data.resourceUrl;
     }
 
+    // Create a default context for file transfer operations for the recovered session
+    const contextName = `file-transfer-context-${Date.now()}`;
+    const contextResult = await this.context.get(contextName, true);
+    if (contextResult.success && contextResult.context) {
+      session.fileTransferContextId = contextResult.context.id;
+      logInfo(`📁 Created file transfer context for recovered session: ${contextResult.context.id}`);
+    } else {
+      logError(`⚠️  Failed to create file transfer context for recovered session: ${contextResult.errorMessage || 'Unknown error'}`);
+    }
+
     return {
       requestId: getResult.requestId,
       success: true,

--- a/typescript/tests/integration/get-file-transfer-context.test.ts
+++ b/typescript/tests/integration/get-file-transfer-context.test.ts
@@ -1,0 +1,176 @@
+import { AgentBay, Session } from "../../src";
+import { getTestApiKey } from "../utils/test-helpers";
+import { log } from "../../src/utils/logger";
+
+/**
+ * Integration tests for the get method file transfer context fix.
+ *
+ * This test suite verifies that the get() method properly creates a file transfer
+ * context when recovering a session, allowing file operations to work correctly.
+ */
+describe("Get Method File Transfer Context", () => {
+  let agentBay: AgentBay;
+  let testSession: Session;
+
+  beforeEach(async () => {
+    const apiKey = getTestApiKey();
+    agentBay = new AgentBay({ apiKey });
+
+    // Create a test session
+    log("Creating test session...");
+    const createResult = await agentBay.create({ imageId: "code_latest" });
+
+    expect(createResult.success).toBe(true);
+    expect(createResult.session).toBeDefined();
+
+    testSession = createResult.session!;
+    log(`Test session created with ID: ${testSession.sessionId}`);
+  });
+
+  afterEach(async () => {
+    // Cleanup: delete the session after test
+    if (testSession) {
+      try {
+        log(`Cleaning up session: ${testSession.sessionId}`);
+        await agentBay.delete(testSession);
+      } catch (error) {
+        log(`Warning: Failed to cleanup session ${testSession.sessionId}: ${error}`);
+      }
+    }
+  });
+
+  it("should create file transfer context when using get method", async () => {
+    /**
+     * Test that get method creates file transfer context automatically.
+     *
+     * This test verifies the fix for the bug where recovered sessions
+     * couldn't perform file operations due to missing file transfer context.
+     */
+    log("Testing get method creates file transfer context...");
+
+    // Get the session_id from the test session
+    const sessionId = testSession.sessionId;
+
+    // Use get method to recover the session
+    const getResult = await agentBay.get(sessionId);
+
+    // Verify get was successful
+    expect(getResult.success).toBe(true);
+    expect(getResult.session).toBeDefined();
+    expect(getResult.session!.sessionId).toBe(sessionId);
+
+    // Verify that the recovered session has a file transfer context ID
+    const recoveredSession = getResult.session!;
+    expect(recoveredSession.fileTransferContextId).toBeDefined();
+    expect(recoveredSession.fileTransferContextId).not.toBeNull();
+    expect(recoveredSession.fileTransferContextId).not.toBe("");
+
+    log(`File transfer context ID: ${recoveredSession.fileTransferContextId}`);
+  });
+
+  it("should perform file operations on recovered session", async () => {
+    /**
+     * Test that recovered session can perform actual file operations.
+     *
+     * This is an end-to-end test that verifies the recovered session
+     * can actually upload and download files.
+     */
+    log("Testing recovered session can perform file operations...");
+
+    // Get the session_id from the test session
+    const sessionId = testSession.sessionId;
+
+    // Wait a bit for session to be fully ready
+    await new Promise(resolve => setTimeout(resolve, 5000));
+
+    // Use get method to recover the session
+    const getResult = await agentBay.get(sessionId);
+    expect(getResult.success).toBe(true);
+
+    const recoveredSession = getResult.session!;
+
+    // Create a test file to upload
+    const testContent = `Test content at ${Date.now()}`;
+    const testFilename = `test_file_${Date.now()}.txt`;
+    const testPath = `/tmp/${testFilename}`;
+
+    // Try to write the file using file_system operations
+    // This should work if file transfer context is properly set up
+    log(`Writing file: ${testPath}`);
+    const writeResult = await recoveredSession.fileSystem.writeFile(
+      testPath,
+      testContent
+    );
+
+    // Verify the write was successful
+    expect(writeResult.success).toBe(true);
+
+    // Read back the file to verify
+    log(`Reading file: ${testPath}`);
+    const readResult = await recoveredSession.fileSystem.readFile(testPath);
+
+    expect(readResult.success).toBe(true);
+    expect(readResult.content).toBe(testContent);
+
+    log("File operations completed successfully");
+  });
+
+  it("should allow both original and recovered sessions to work", async () => {
+    /**
+     * Test that both original session and recovered session can perform file operations.
+     *
+     * This test verifies that:
+     * 1. Original session created with create() works
+     * 2. Recovered session obtained with get() works
+     * 3. Both can perform file operations independently
+     */
+    log("Testing both original and recovered sessions...");
+
+    const sessionId = testSession.sessionId;
+
+    // Wait a bit for session to be fully ready
+    await new Promise(resolve => setTimeout(resolve, 5000));
+
+    // Test 1: Original session can write files
+    const testContent1 = `Original session test at ${Date.now()}`;
+    const testFilename1 = `original_test_${Date.now()}.txt`;
+    const testPath1 = `/tmp/${testFilename1}`;
+
+    log(`Original session writing file: ${testPath1}`);
+    const writeResult1 = await testSession.fileSystem.writeFile(
+      testPath1,
+      testContent1
+    );
+    expect(writeResult1.success).toBe(true);
+
+    // Test 2: Recover the session
+    log("Recovering session...");
+    const getResult = await agentBay.get(sessionId);
+    expect(getResult.success).toBe(true);
+    const recoveredSession = getResult.session!;
+
+    // Test 3: Recovered session can write files
+    const testContent2 = `Recovered session test at ${Date.now()}`;
+    const testFilename2 = `recovered_test_${Date.now()}.txt`;
+    const testPath2 = `/tmp/${testFilename2}`;
+
+    log(`Recovered session writing file: ${testPath2}`);
+    const writeResult2 = await recoveredSession.fileSystem.writeFile(
+      testPath2,
+      testContent2
+    );
+    expect(writeResult2.success).toBe(true);
+
+    // Test 4: Verify both files exist and have correct content
+    log("Verifying both files...");
+    const readResult1 = await recoveredSession.fileSystem.readFile(testPath1);
+    expect(readResult1.success).toBe(true);
+    expect(readResult1.content).toBe(testContent1);
+
+    const readResult2 = await recoveredSession.fileSystem.readFile(testPath2);
+    expect(readResult2.success).toBe(true);
+    expect(readResult2.content).toBe(testContent2);
+
+    log("Both sessions work correctly");
+  });
+});


### PR DESCRIPTION
When using the get() method to recover a session by session_id, the recovered session lacked a file transfer context that is automatically created during session creation. This caused file operations to fail with "No context ID" errors.

This fix ensures that get() method creates a file transfer context for recovered sessions, enabling file operations to work correctly.

Changes:
- Python: Added context creation logic in agentbay.py get() method
- TypeScript: Added context creation logic in agent-bay.ts get() method
- Golang: Added context creation logic in agentbay.go get() method
- Golang: Added FileTransferContextID field to Session struct
- All: Added comprehensive integration tests (3 test cases per SDK)

Test Coverage:
- Verify get() method creates file transfer context automatically
- Verify recovered session can perform file operations
- Verify both original and recovered sessions work independently

All tests passing:
- Python: 3/3 tests passed
- TypeScript: 3/3 tests passed
- Golang: 3/3 tests passed

🤖 Generated with [Claude Code]