### PR TITLE
fix: resolve relative import error in e-commerce-inspector langchain …

### DIFF
--- a/cookbook/envs/browser/e-commerce-inspector/langchain/src/e_commerce_inspector.py
+++ b/cookbook/envs/browser/e-commerce-inspector/langchain/src/e_commerce_inspector.py
@@ -14,7 +14,7 @@ from agentbay.session import Session
 from agentbay.session_params import CreateSessionParams
 from agentbay.browser.browser import BrowserOption, BrowserScreen
 
-from .inspector_tools import process_site
+from inspector_tools import process_site
 
 
 class ECommerceInspector:


### PR DESCRIPTION
…example

Fixed ImportError in cookbook/envs/browser/e-commerce-inspector/langchain example.

Problem:
- e_commerce_inspector.py used relative import `from .inspector_tools import process_site`
- When running the example script directly with `python src/e_commerce_inspector_example.py`, Python raised "ImportError: attempted relative import with no known parent package"

Solution:
- Changed relative import to absolute import: `from inspector_tools import process_site`
- This allows the example to run correctly when executed as a script

Tested:
- Import validation passed
- Script can now run without import errors

🤖 Generated with [Claude Code]